### PR TITLE
Fix: revertDeletion() remove input from HTML

### DIFF
--- a/javascript/file_attachment_field.js
+++ b/javascript/file_attachment_field.js
@@ -470,7 +470,8 @@ DroppedFile.prototype = {
      * Undoes a detach/delete state     
      */
     revertDeletion: function () {
-        var del = this.getHolder().querySelector('input.input-deleted-file[value="'+this.getIdentifier()+'"]');
+	var holder = this.uploader.node.querySelector('.attached-file-deletions');    
+	var del = holder.querySelector('input.input-deleted-file[value="'+this.getIdentifier()+'"]');
         if(del) {
             del.parentNode.removeChild(del);
         }


### PR DESCRIPTION
Fixes #17: get the correct holder for the '.attached-file-deletions' selector, to remove the <input class="input-deleted-file"