### PR TITLE
NEW Save/load info from CSV of IDs

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -188,11 +188,11 @@ class FileAttachmentField extends FileField {
 
         if($relation = $this->getRelation()) {            
             $relation->setByIDList($this->Value());            
-        }
-
-        elseif($record->has_one($fieldname)) {            
+        } elseif($record->has_one($fieldname)) {            
             $record->{"{$fieldname}ID"} = $this->Value() ?: 0;
-        }
+        } elseif($record->hasField($fieldname)) {
+			$record->$fieldname = is_array($this->Value()) ? implode(',', $this->Value()) : $this->Value();
+		}
 
         return $this;
     }
@@ -608,6 +608,21 @@ class FileAttachmentField extends FileField {
                 }
             }
         }
+		
+		if ($ids = $this->dataValue()) {
+			if (!is_array($ids)) {
+				$ids = explode(',', $ids);
+			}
+
+			$attachments = ArrayList::create();
+			foreach ($ids as $id) {
+				$file = File::get()->byID((int) $id);
+				if ($file && $file->canView()) {
+					$attachments->push($file);
+				}
+			}
+			return $attachments;
+		}
 
         return false;
     }


### PR DESCRIPTION
Allow mapping upload file IDs to a non-relationship field on a data object
as a comma separated list of IDs (and loading attachments from the same field)
instead of requiring a relationship to exist on a record.

Makes it easier to incorporate in other form types where a record doesn't
necessarily exist at the time of loading the form, but a value can be
set.