### PR TITLE
Add config options to specify where javascripts and front-end config is loaded.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,7 +3,9 @@ Name: dropzone
 After: 'framework/*','cms/*'
 ---
 FileAttachmentField:
-  default_config_path: 'javascript/default_config.json'
+  module_scripts_dir: 'javascript/'
+  dropzone_script_file: 'javascript/dropzone.js'
+  dropzone_config_file: 'javascript/default_config.json'
   icon_sizes: [16, 32, 48, 64, 128, 512]
   upgrade_images: true
   list_thumbnail_width: 64
@@ -20,6 +22,6 @@ FileAttachmentField:
     clickable: '.dropzone-select'
     auto_process_queue: true
     auto_queue: true
-    add_remove_links: false    
+    add_remove_links: false
 File:
   extensions: [DropzoneFile]

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wakes/silverstripe-dropzone",
+    "name": "unclecheese/dropzone",
     "description": "An HTML5 upload field for the CMS and frontend forms.",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "upload", "uploader", "files", "forms", "cms"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "unclecheese/dropzone",
+    "name": "wakes/silverstripe-dropzone",
     "description": "An HTML5 upload field for the CMS and frontend forms.",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "upload", "uploader", "files", "forms", "cms"],


### PR DESCRIPTION
Added configuration settings:
```
FileAttachmentField:
  module_scripts_dir: 'javascript/'
  dropzone_script_file: 'javascript/dropzone.js'
  dropzone_config_file: 'javascript/default_config.json'
```
to specify where javascript and front-end config is loaded from more succinctly.

Thanks for the awesome upload field!