### PR TITLE
Updating FileAttachmentField so it works when rendered in a SmallFieldHolder 

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -154,7 +154,7 @@ class FileAttachmentField extends FileField {
      */
     public function SmallFieldHolder($attributes = array ()) {
         $this->defineFieldHolderRequirements();
-        return parent::FieldHolder($attributes);
+        return parent::SmallFieldHolder($attributes);
     }
 
     /**

--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -137,10 +137,30 @@ class FileAttachmentField extends FileField {
      * Renders the form field, loads requirements. Sets file size based on php.ini
      * Adds the security token
      *
-     * @param array $attributes [description]
+     * @param array $attributes
      * @return  SSViewer
      */
     public function FieldHolder($attributes = array ()) {
+        $this->defineFieldHolderRequirements();
+        return parent::FieldHolder($attributes);
+    }
+
+    /**
+     * Renders the small form field holder, loads requirements. Sets file size based on php.ini
+     * Adds the security token
+     *
+     * @param array $attributes
+     * @return  SSViewer
+     */
+    public function SmallFieldHolder($attributes = array ()) {
+        $this->defineFieldHolderRequirements();
+        return parent::FieldHolder($attributes);
+    }
+
+    /**
+     * Define some requirements and settings just before rendering the Field Holder.
+     */
+    protected function defineFieldHolderRequirements() {
         Requirements::javascript(DROPZONE_DIR.'/javascript/dropzone.js');
         Requirements::javascript(DROPZONE_DIR.'/javascript/file_attachment_field.js');
         if($this->isCMS()) {
@@ -169,9 +189,6 @@ class FileAttachmentField extends FileField {
         if($token = $this->getForm()->getSecurityToken()) {
             $this->addParam($token->getName(), $token->getSecurityID());
         }
-
-
-        return parent::FieldHolder($attributes);
     }
 
     /**
@@ -409,7 +426,7 @@ class FileAttachmentField extends FileField {
 
     	return $this;
     }
-    
+
     /**
      * Sets the min resolution for images, in pixels
      * @param int $pixels
@@ -951,7 +968,7 @@ class FileAttachmentField extends FileField {
         $data['params'] = $this->params;
         $data['thumbnailsDir'] = $this->ThumbnailsDir();
         $data['thumbnailWidth'] = $this->getSelectedThumbnailWidth();
-        $data['thumbnailHeight'] = $this->getSelectedThumbnailHeight();        
+        $data['thumbnailHeight'] = $this->getSelectedThumbnailHeight();
 
         if(!$this->IsMultiple()) {
             $data['maxFiles'] = 1;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "firebrandhq/dropzone",
+    "name": "unclecheese/dropzone",
     "description": "An HTML5 upload field for the CMS and frontend forms.",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "upload", "uploader", "files", "forms", "cms"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "unclecheese/dropzone",
+    "name": "firebrandhq/dropzone",
     "description": "An HTML5 upload field for the CMS and frontend forms.",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "upload", "uploader", "files", "forms", "cms"],

--- a/templates/forms/FileAttachmentField_holder_small.ss
+++ b/templates/forms/FileAttachmentField_holder_small.ss
@@ -1,0 +1,53 @@
+<div id="$Name" class="field<% if $extraClass %> $extraClass<% end_if %> supported">
+    <% if $Title %><label class="left" for="$ID">$Title</label><% end_if %>
+    <div id="{$Name}Dropzone" class="dropzone-holder <% if $isCMS %>backend<% end_if %> <% if $CanUpload %>uploadable<% end_if %>" data-config='$ConfigJSON'>
+        <p>
+            <% if $IsMultiple && $CanUpload %>
+                <%t Dropzone.ATTACHFILESHERE_OR "Attach files by dropping them in here." %>
+            <% else_if $CanUpload %>
+                <%t Dropzone.ATTACHFILEHERE_OR "Attach a file by dropping it in here." %>
+            <% end_if %>
+
+            <% if $CanUpload && $CanAttach %><br><% end_if %>
+            <% if $CanUpload || $CanAttach %>
+                <% if $CanUpload %><%t Dropzone.YOUCANALSO "You can also" %> <% end_if %>
+                <% if $CanUpload %>[<a class="dropzone-select"><%t Dropzone.BROWSEYOURCOMPUTER "browse your computer" %></a>]<% end_if %>
+                <% if $CanUpload && $CanAttach %> <%t Dropzone.OR " or " %> <% end_if %>
+                <% if $CanAttach %>[<a class="dropzone-select-existing"><%t Dropzone.CHOOSEEXISTING "choose from existing files" %></a>]<% end_if %>
+            <% end_if %>
+
+        </p>
+        <ul data-container data-attachments class="file-attachment-field-previews $View">
+            <% if $AttachedFiles %>
+                <% loop $AttachedFiles %>
+                    <% include FileAttachmentField_attachments File=$Me, Scope=$Up %>
+                <% end_loop %>
+            <% end_if %>
+        </ul>
+
+
+
+        <template>
+            $PreviewTemplate
+        </template>
+        <div class="attached-file-inputs" data-input-name="$InputName">
+            <% if $AttachedFiles %>
+                <% loop $AttachedFiles %>
+                <input class="input-attached-file" type="hidden" name="$Up.InputName" value="$ID">
+                <% end_loop %>
+            <% end_if %>
+        </div>
+        <div class="attached-file-deletions" data-input-name="$InputName"></div>
+        <div style="clear:both;"></div>
+
+        <% if not $AutoProcess %>
+            <button class="process" data-auto-process><%t Dropzone.UPLOADFILES "Upload file(s)" %></button>
+        <% end_if %>
+
+    </div>
+
+    <div class="unsupported">
+        <p><strong><%t Dropzone.NOTSUPPORTED "Your browser does not support HTML5 uploads. Please update to a newer version." %></strong></p>
+    </div>
+
+</div>


### PR DESCRIPTION
Thanks a lot for this plugin. It's very helpful.

I notice that the FileAttachmentField doesn't work properly when it's rendered in a Small Field Holder (e.g.: like when the FileAttachmentField as added to a Group).

After looking at the source code, I noticed that FileAttachmentField overrides the `FieldHolder` function to define a bunch of requirements and set some settings, but that it doesn't do the same for `SmallFieldHolder` function.

I've moved the logic of the `FieldHolder` function to a protected `defineFieldHolderRequirements` function. The `FieldHolder` and `SmallFieldHolder` functions now called that protected function before calling their respective parents.

I've also added a `FileAttachmentField_holder_small.ss` template. It's a straight copy of `FileAttachmentField_holder.ss`.

Let me know if you have any concerns with this pull request or would like me to adjust any thing.