### PR TITLE
Feature(FileTracking): Track files as their uploaded via AJAX, and remove track log after save

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -547,7 +547,7 @@ class FileAttachmentField extends FileField {
      */
     public function setAcceptedMimeTypes($types = array ()) {
         if(is_array($types)) {
-            $types = explode(',', $types);
+            $types = implode(',', $types);
         }
         $this->settings['acceptedMimeTypes'] = $types;
 

--- a/code/FileAttachmentFieldCleanTask.php
+++ b/code/FileAttachmentFieldCleanTask.php
@@ -3,8 +3,8 @@
 /**
  * Delete all files being tracked that weren't saved against anything.
  *
- * WARNING: You must call 'FileAttachmentFieldTrack::untrack' against IDs on custom-built forms or you
- *          -will- remove files accidentally.
+ * WARNING: You must call Form::saveInto or 'FileAttachmentFieldTrack::untrack' against IDs on custom-built forms or you
+ *          -will- remove files accidentally with this task.
  *
  * @package  unclecheese/silverstripe-dropzone
  */
@@ -19,7 +19,7 @@ class FileAttachmentFieldCleanTask extends BuildTask {
         if ($files) {
             foreach ($files as $trackRecord) {
                 $file = $trackRecord->File();
-                if ($file && $file->exists()) {
+                if ($file->exists()) {
                     DB::alteration_message('Remove File #'.$file->ID.' from "'.$trackRecord->ControllerClass.'" on '.$trackRecord->RecordClass.' #'.$trackRecord->RecordID, 'error');
                     $file->delete();
                 } else {

--- a/code/FileAttachmentFieldCleanTask.php
+++ b/code/FileAttachmentFieldCleanTask.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Delete all files being tracked that weren't saved against anything.
+ *
+ * @package  unclecheese/silverstripe-dropzone
+ */
+class FileAttachmentFieldCleanTask extends BuildTask {
+    protected $title = "File Attachment Field - Clear tracked files";
+    
+    protected $description = 'Delete files uploaded via FileAttachmentField that aren\'t attached to anything';
+    
+    public function run($request) {
+        $files = FileAttachmentFieldTrack::get()->filter(array('Created:LessThanOrEqual' => date('Y-m-d H:i:s', time()-3600)));
+        $files = $files->toArray();
+        if ($files) {
+            foreach ($files as $trackRecord) {
+                $file = $trackRecord->File();
+                if ($file && $file->exists()) {
+                    DB::alteration_message('Remove File #'.$file->ID.' from "'.$trackRecord->FormClass.'" on Page #'.$trackRecord->PageID, 'changed');
+                    $file->delete();
+                }
+                $trackRecord->delete();
+            }
+        } else {
+            DB::alteration_message('No tracked files to remove.');
+        }
+    }
+}

--- a/code/FileAttachmentFieldTrack.php
+++ b/code/FileAttachmentFieldTrack.php
@@ -7,7 +7,6 @@
  */
 class FileAttachmentFieldTrack extends DataObject {
     private static $db = array(
-        'SessionID' => 'Varchar(255)',
         'ControllerClass' => 'Varchar(60)',
         'RecordID' => 'Int',
         'RecordClass' => 'Varchar(60)',
@@ -31,8 +30,6 @@ class FileAttachmentFieldTrack extends DataObject {
     public function onBeforeWrite() {
         parent::onBeforeWrite();
         if (!$this->exists()) {
-            $this->SessionID = session_id();
-
             // Store record this file was tracked on.
             if (!$this->RecordID && Controller::has_curr()) {
                 $controller = Controller::curr();

--- a/code/FileAttachmentFieldTrack.php
+++ b/code/FileAttachmentFieldTrack.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Track files as they're uploaded and remove when they've been saved.
+ * NOTE: Run task to cleanup leftover files.
+ *
+ * @package  unclecheese/silverstripe-dropzone
+ */
+class FileAttachmentFieldTrack extends DataObject {
+    private static $db = array(
+        'SessionID' => 'Varchar(255)',
+        'FormClass' => 'Varchar(60)',
+    );
+
+    private static $has_one = array(
+        'File' => 'File',
+        'Page' => 'SiteTree',
+    );
+
+    public function onBeforeWrite() {
+        parent::onBeforeWrite();
+        if (!$this->exists()) {
+            $this->SessionID = session_id();
+
+            // Store page this file was tracked on.
+            if (Controller::has_curr()) {
+                $controller = Controller::curr();
+                if ($controller->hasMethod('data')) {
+                    $pageRecord = $controller->data();
+                    if ($pageRecord && $pageRecord instanceof DataObjectInterface) {
+                        $this->PageID = $pageRecord->ID;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/javascript/file_attachment_field.js
+++ b/javascript/file_attachment_field.js
@@ -197,24 +197,28 @@ UploadInterface.prototype = {
      * @param  {File}   file 
      * @param  {Function} done      
      */
-    accept: function (file, done) {
-    	if(this.settings.maxResolution && file.type.match(/image.*/)) {
-			this.checkImageResolution(file, this.settings.maxResolution, function (result, width, height) {
-				var msg = null;
-				if(!result) {
+	accept: function (file, done) {
+    	if((this.settings.maxResolution || this.settings.minResolution) && file.type.match(/image.*/)) {
+		this.checkImageResolution(file, this.settings.maxResolution, this.settings.minResolution, function (result, errorType, width, height) {
+			var msg = null;
+			if(!result) {
+				if(errorType == "big"){
 					msg = 'Resolution is too high. Please resize to ' + width + 'x' + height + ' or smaller';
+				}else{
+					msg = 'Resolution is too small. Please resize to ' + width + 'x' + height + ' or bigger';
 				}
-				try {				
-					done(msg);
-				}
-				// Because this check is asynchronous, the file has already been queued at this point
-				// and Dropzone throws an error for queuing a rejected file. Just ignore it.
-				catch (e) {}
-			});
-		}
-		else {
-			return done();
-		}
+			}
+			try {				
+				done(msg);
+			}
+			// Because this check is asynchronous, the file has already been queued at this point
+			// and Dropzone throws an error for queuing a rejected file. Just ignore it.
+			catch (e) {}
+		});
+	}
+	else {
+		return done();
+	}
     },
 
     /**

--- a/templates/forms/FileAttachmentField_holder.ss
+++ b/templates/forms/FileAttachmentField_holder.ss
@@ -39,7 +39,6 @@
         </div>
         <div class="attached-file-deletions" data-input-name="$InputName"></div>
         <div style="clear:both;"></div>
-
         <% if not $AutoProcess %>
             <button class="process" data-auto-process><%t Dropzone.UPLOADFILES "Upload file(s)" %></button>
         <% end_if %>
@@ -50,4 +49,5 @@
         <p><strong><%t Dropzone.NOTSUPPORTED "Your browser does not support HTML5 uploads. Please update to a newer version." %></strong></p>
     </div>
 
+    <% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
 </div>


### PR DESCRIPTION
DO NOT ACCEPT PR YET. Give this say... a week or two so any edge cases are found.

**Goal:** Stop users from uploading lots of files and filling the servers HDD on the frontend.

Add optional config to track each file thats uploaded. A file is removed from the track log for CMS Forms / anything that uses 'saveInto'.

Then a task can be run to remove all files that never ended up being attached to anything.

When dealing with custom forms, if a user does not use 'saveInto', they will need to manually untrack the file IDs with something like: "FileAttachmentFieldTrack::untrack($data['MyUploadField'])"