### PR TITLE
Fix checkImageResolution validation messages

### DIFF
--- a/javascript/file_attachment_field.js
+++ b/javascript/file_attachment_field.js
@@ -286,13 +286,13 @@ UploadInterface.prototype = {
 						var ratio = imageH / imageW,
 							maxWidth = Math.floor(Math.sqrt(maxPixels / ratio)),
 							maxHeight = Math.round(maxWidth * ratio);
-							callback(false, maxWidth, maxHeight);
+							callback(false, 'big', maxWidth, maxHeight);
 					}
 				        if (pixels < minPixels) {
 						var ratio = imageH / imageW,
 							minWidth = Math.floor(Math.sqrt(minPixels / ratio)),
 							minHeight = Math.round(minWidth * ratio);
-							callback(false, minWidth, minHeight);
+							callback(false, 'small', minWidth, minHeight);
 
 					}
 


### PR DESCRIPTION
Currently these are broken, compare the function declaration [here](https://github.com/unclecheese/silverstripe-dropzone/blob/b3cb1666ff5c59f0747ac6f54b87a6c8b052fcaf/javascript/file_attachment_field.js#L202) with how it’s being called - it always thinks the image is too small, and suggests resizing it to [dimension] x undefined.