### PR TITLE
fix(SecurityID): Change FileAttachmentField to get SecurityID from the relative <form>

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -199,10 +199,6 @@ class FileAttachmentField extends FileField {
                 $this->imagesOnly();
             }
         }
-
-        if($token = $this->getForm()->getSecurityToken()) {
-            $this->addParam($token->getName(), $token->getSecurityID());
-        }
     }
 
     /**
@@ -1180,7 +1176,7 @@ class FileAttachmentField extends FileField {
             }
         }
 
-        $data['params'] = $this->params;
+        $data['params'] = ($this->params) ? $this->params : null;
         $data['thumbnailsDir'] = $this->ThumbnailsDir();
         $data['thumbnailWidth'] = $this->getSelectedThumbnailWidth();
         $data['thumbnailHeight'] = $this->getSelectedThumbnailHeight();

--- a/javascript/file_attachment_field.js
+++ b/javascript/file_attachment_field.js
@@ -13,6 +13,20 @@ var UploadInterface = function (node, backend) {
     this.settings = JSON.parse(node.getAttribute('data-config'));
     this.node = node;
     this.droppedFiles = [];
+    if (!this.settings.params) {
+        this.settings.params = {};
+    }
+
+    if (!this.settings.params.SecurityID) {
+        var formNode = this.node;
+        do {
+            formNode = formNode.parentNode;
+        } while (formNode && formNode.tagName !== 'FORM' && formNode.nodeType !== 11);
+        var securityIDNode = formNode.querySelector("input[name=\"SecurityID\"]");
+        if (securityIDNode) {
+            this.settings.params.SecurityID = securityIDNode.value;
+        }
+    }
     
     if(template) {
         this.settings.previewTemplate = template.innerHTML;


### PR DESCRIPTION
fix(SecurityID): Change FileAttachmentField to get SecurityID from the relative <form>, this was to fix DynamicCache incompatibilities as it uses regex on cached HTML pages to replace the SecurityID appropriately.

- $data['params'] is set to null to avoid it being a regular array when being converted to JavaScript when it's empty.