### PR TITLE
fix(file_attachment_field): Fix JavaScript where classList

### DIFF
--- a/javascript/file_attachment_field.js
+++ b/javascript/file_attachment_field.js
@@ -40,7 +40,9 @@ var UploadInterface = function (node, backend) {
     this.settings.fallback = UploadInterface.prototype.fallback.bind(this);
     this.settings.accept = UploadInterface.prototype.accept.bind(this);
     
-    if(this.node.classList.contains('uploadable')) {
+    if (document.documentElement.classList && this.node.classList.contains('uploadable')) {
+        this.backend = new backend(this.node, this.settings);
+    } else if (this.node.className.indexOf('uploadable') !== -1) {
         this.backend = new backend(this.node, this.settings);
     }
 


### PR DESCRIPTION
fix(file_attachment_field): Fix JavaScript where classList (IE9 and lower) isn't supported breaks showing the \<div class="unsupported"\>\</div\> fallback.

Related:
https://github.com/unclecheese/silverstripe-dropzone/issues/74