### PR TITLE
Allow custom root thumbnail dir

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -890,7 +890,15 @@ class FileAttachmentField extends FileField {
      * @return  string
      */
     public function RootThumbnailsDir() {
-        return $this->getSetting('thumbnailsDir') ?: DROPZONE_DIR.'/images/file-icons';
+        if($this->getSetting('thumbnailsDir')) {
+            return $this->getSetting('thumbnailsDir');
+        } 
+
+        if($this->config()->root_thumbnails_dir) {
+            return $this->config()->root_thumbnails_dir;
+        }
+        
+        return DROPZONE_DIR . '/images/file-icons';
     }
 
     /**


### PR DESCRIPTION
Allows

```yaml
FileAttachmentField:
  root_thumbnails_dir: 'mysite/filetype-icons'
```