### PR TITLE
fix(FileAttachmentField): If setMaxFiles() is above 1, call setMultiple(true)

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -309,6 +309,11 @@ class FileAttachmentField extends FileField {
      */
     public function setMaxFiles($num){
         $this->settings['maxFiles'] = $num;
+        if ($num > 1) {
+            $this->setMultiple(true);
+        } else {
+            $this->setMultiple(false);
+        }
 
         return $this;
     }


### PR DESCRIPTION
If setMaxFiles() is above 1, call setMultiple(true).

Any reason this behaviour wasn't already in the module?
(Related issue: https://github.com/unclecheese/silverstripe-dropzone/issues/83)