### PR TITLE
Handle uncaught invalid single values.

### DIFF
--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -429,10 +429,13 @@ class FileAttachmentField extends FileField {
                 "validation"
             );
             $result = false;
-        } else if ($value && is_array($value)) {
+        } else if ($value) {
             // Prevent a malicious user from inspecting element and changing
             // one of the <input type="hidden"> fields to use an invalid File ID.
             $validIDs = $this->getValidFileIDs();
+            if (!is_array($value)) {
+                $value = array($value);
+            }
             foreach ($value as $id) {
                 if (!isset($validIDs[$id])) {
                     if ($validator) {


### PR DESCRIPTION
It appears that in SilverStripe 3.6.1 (if not others) that single-valued field values can be passed in from the client. These values do not get checked to see whether they refer to validFileIDs from the session.

The change here is to ensure that single values (that are not in an array) are also checked against the valid file ids.