### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,9 @@
 <?php
 
 define('DROPZONE_DIR', basename(dirname(__FILE__)));
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/FileAttachmentField.php
+++ b/code/FileAttachmentField.php
@@ -840,7 +840,7 @@ class FileAttachmentField extends FileField {
               return $this->httpError(400, $user_message);
             }
             if($relationClass = $this->getFileClass($tmpFile['name'])) {
-                $fileObject = Object::create($relationClass);
+                $fileObject = SS_Object::create($relationClass);
             }
 
             try {


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors).