### PR TITLE
BUGFIX: Fixed crash when the value of the FileAttachmentField is set from a DataObject

### DIFF
--- a/src/FileAttachmentField.php
+++ b/src/FileAttachmentField.php
@@ -549,12 +549,12 @@ class FileAttachmentField extends FileField
             //       an already saved DataObject.
             $fieldName = $this->getName();
             $ids = array();
-            if ($data->hasOneComponent($fieldName)) {
+            if ($data->getSchema()->hasOneComponent(get_class($data), $fieldName)) {
                 $id = $data->{$fieldName.'ID'};
                 if ($id) {
                     $ids[] = $id; 
                 }
-            } else if ($data->hasManyComponent($fieldName) || $data->manyManyComponent($fieldName)) {
+            } else if ($data->getSchema()->hasManyComponent(get_class($data), $fieldName) || $data->getSchema()->manyManyComponent(get_class($data), $fieldName)) {
                 $files = $data->{$fieldName}();
                 if ($files) {
                     foreach ($files as $file) {


### PR DESCRIPTION
This pull request fixes a crash when the `FileAttachmentField`'s value is set from a DataObject, in short the `hasOneComponent`, `hasManyComponent`, and `manyManyComponent` methods have moved into `DataObjectSchema`.