### PR TITLE
FIX: Thumbnail path and file class reference issue

### DIFF
--- a/src/DropzoneFile.php
+++ b/src/DropzoneFile.php
@@ -83,7 +83,7 @@ class DropzoneFile extends DataExtension
      */
     protected function getFilenameForType($ext, $size)
     {
-        return ModuleResourceLoader::singleton()->resolveResource(sprintf(
+        return ModuleResourceLoader::singleton()->resolveURL(sprintf(
             'unclecheese/dropzone:images/file-icons/%spx/%s.png',
             $size,
             strtolower($ext)

--- a/src/FileAttachmentField.php
+++ b/src/FileAttachmentField.php
@@ -1139,7 +1139,7 @@ class FileAttachmentField extends FileField
     public function RootThumbnailsDir()
     {
         return $this->getSetting('thumbnailsDir') ?:
-            ModuleResourceLoader::singleton()->resolveResource('unclecheese/dropzone:images/file-icons')->getURL();
+            ModuleResourceLoader::singleton()->resolveURL('unclecheese/dropzone:images/file-icons');
     }
 
     /**

--- a/src/FileAttachmentField.php
+++ b/src/FileAttachmentField.php
@@ -1139,7 +1139,7 @@ class FileAttachmentField extends FileField
     public function RootThumbnailsDir()
     {
         return $this->getSetting('thumbnailsDir') ?:
-            ModuleResourceLoader::singleton()->resolveResource('unclecheese/dropzone:images/file-icons');
+            ModuleResourceLoader::singleton()->resolveResource('unclecheese/dropzone:images/file-icons')->getURL();
     }
 
     /**

--- a/src/FileAttachmentFieldTrack.php
+++ b/src/FileAttachmentFieldTrack.php
@@ -2,6 +2,7 @@
 
 namespace UncleCheese\Dropzone;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
@@ -20,7 +21,7 @@ class FileAttachmentFieldTrack extends DataObject
     );
 
     private static $has_one = array(
-        'File' => 'File',
+        'File' => File::class,
     );
 
     private static $table_name = 'FileAttachmentFieldTrack';


### PR DESCRIPTION
This pull fixes an issue where the path to the file icons and other image assets used in the field would not properly resolve to the resources folder. As well it also fixes an issue where `FileAttachmentFieldTrack` was not referencing the namespaced File class.