### PR TITLE
Fix int casting when the value obtained in AttachedFiles contains a File rather than a file ID

### DIFF
--- a/src/FileAttachmentField.php
+++ b/src/FileAttachmentField.php
@@ -1120,7 +1120,7 @@ class FileAttachmentField extends FileField
 
             $attachments = ArrayList::create();
             foreach ($ids as $id) {
-                if($id instanceof File) {
+                if ($id instanceof File) {
                     $file = $id;
                 } else {
                     $file = File::get()->byID((int) $id);

--- a/src/FileAttachmentField.php
+++ b/src/FileAttachmentField.php
@@ -1120,7 +1120,11 @@ class FileAttachmentField extends FileField
 
             $attachments = ArrayList::create();
             foreach ($ids as $id) {
-                $file = File::get()->byID((int) $id);
+                if($id instanceof File) {
+                    $file = $id;
+                } else {
+                    $file = File::get()->byID((int) $id);
+                }
                 if ($file && $file->canView()) {
                     $attachments->push($file);
                 }


### PR DESCRIPTION
I've occasionally encountered an issue where `$ids` contained an instance of the File itself rather than a reference via its ID, this PR checks we don't already have the file before casting the value to an integer.

I've not had a chance to check whether there's an upstream change which has caused this but if I find it i'll update the PR.